### PR TITLE
Pass options to initialization when adding a bucket

### DIFF
--- a/lib/octopress-deploy.rb
+++ b/lib/octopress-deploy.rb
@@ -44,7 +44,7 @@ module Octopress
 
     def self.add_bucket(options={})
       options = merge_configs(options)
-      get_deployment_method(options).new().add_bucket()
+      get_deployment_method(options).new(options).add_bucket()
     end
 
     def self.merge_configs(options={})


### PR DESCRIPTION
Currently, running the command `octopress deploy add-bucket` generates the following error:

```
/octopress-deploy-1.0.0.rc.9/lib/octopress-deploy/s3.rb:8:in `initialize': wrong number of arguments (0 for 1) (ArgumentError)
```

This is because the deployment options used for setting up an S3 bucket are not passed on to the S3's class [initialization method](https://github.com/octopress/deploy/blob/master/lib/octopress-deploy/s3.rb#L8).

This PR adds the options hash as the arguments to the initialization call to S3.

Users should now be able to add buckets when setting up deployment.
