### PR TITLE
quick fix for octopress/deploy#41

### DIFF
--- a/lib/octopress-deploy/s3.rb
+++ b/lib/octopress-deploy/s3.rb
@@ -83,6 +83,8 @@ module Octopress
       def get_file_with_metadata(file, s3_filename)
         file_with_options = {:file => file }
 
+        file_with_options[:acl] = :public_read
+
         @headers.each do |conf|
           if conf.has_key? 'filename' and s3_filename.match(conf['filename'])
             if @verbose


### PR DESCRIPTION
Makes S3 uploads publicly accessible to fix issue #41.

I tried to do this more properly with a config file option, but wasn't able to get it to actually work (see issue #42).