### PR TITLE
Fixed the S3 deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Mainly you'd do this if you're troubleshooting deployment and you want to see if
 
 ## Amazon S3 Deployment Configuration
 
-To deploy with Amazon S3 you will need to install the [aws-sdk gem](https://rubygems.org/gems/aws-sdk).
+To deploy with Amazon S3 you will need to install the [aws-sdk-v1 gem](https://rubygems.org/gems/aws-sdk-v1).
 
 Important: when using S3, you must add your `_deploy.yml` to your .gitignore to prevent accidentally sharing
 account access information.

--- a/lib/octopress-deploy/s3.rb
+++ b/lib/octopress-deploy/s3.rb
@@ -7,9 +7,9 @@ module Octopress
 
       def initialize(options)
         begin
-          require 'aws-sdk'
+          require 'aws-sdk-v1'
         rescue LoadError
-          abort "Deploying to S3 requires the aws-sdk gem. Install with `gem install aws-sdk`."
+          abort "Deploying to S3 requires the aws-sdk-v1 gem. Install with `gem install aws-sdk-v1`."
         end
         @options     = options
         @local       = options[:site_dir]          || '_site'
@@ -77,7 +77,11 @@ module Octopress
           s3_filename = remote_path(file)
           o = @bucket.objects[s3_filename]
           file_with_options = get_file_with_metadata(file, s3_filename);
-          s3sum = o.etag.tr('"','')
+          begin
+            s3sum = o.etag.tr('"','')
+          rescue AWS::S3::Errors::NoSuchKey
+            s3sum = ""
+          end
 
           if @incremental && (s3sum == Digest::MD5.file(file).hexdigest)
             if @verbose

--- a/octopress-deploy.gemspec
+++ b/octopress-deploy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "octopress"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "clash"
-  spec.add_development_dependency "aws-sdk"
+  spec.add_development_dependency "aws-sdk-v1"
 
   if RUBY_VERSION >= "2"
     spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
1. It appears like the gem is using the aws-sdk-v1 but the dependency is not specific so I got v2 installed which uses a different namespace. Adjusted the gemspec and the require gem name, as well as the README.md to specify the correct gem to install.
2. I am not sure how this gem ever worked to upload new files to Amazon S3, at least with the aws-sdk-v1 version I have. For me, it kept failing with a "No Such Key" exception raised by the AWS SDK. Added a rescue for that specific error to upload the file if it does not already exist in S3.