### PR TITLE
Fixes for rsync include and exclude

### DIFF
--- a/lib/octopress-deploy/rsync.rb
+++ b/lib/octopress-deploy/rsync.rb
@@ -13,8 +13,8 @@ module Octopress
         @exclude_from = @options[:exclude_from]
         @exclude_from = File.expand_path(@exclude_from) if @exclude_from
         @include      = @options[:include]
-        @exclude_from = @options[:include_from]
-        @exclude_from = File.expand_path(@include_from) if @include_from
+        @include_from = @options[:include_from]
+        @include_from = File.expand_path(@include_from) if @include_from
         @delete       = @options[:delete] || false
         @pull_dir     = @options[:dir]
       end
@@ -67,7 +67,7 @@ module Octopress
 #{"# include-from: ".ljust(40)}  # Path to file containing list of files to include
 CONFIG
       end
-      
+
     end
   end
 end

--- a/lib/octopress-deploy/rsync.rb
+++ b/lib/octopress-deploy/rsync.rb
@@ -35,7 +35,6 @@ module Octopress
 
         cmd    =  "rsync "
         cmd    << "#{@flags} "
-        cmd    << " -e"                               if @exclude_from || @exclude
         cmd    << " --exclude-from #{@exclude_from}"  if @exclude_from
         cmd    << " --exclude #{@exclude}"            if @exclude
         cmd    << " --include-from #{@include_from}"  if @include_from

--- a/lib/octopress-deploy/rsync.rb
+++ b/lib/octopress-deploy/rsync.rb
@@ -36,9 +36,13 @@ module Octopress
         cmd    =  "rsync "
         cmd    << "#{@flags} "
         cmd    << " --exclude-from #{@exclude_from}"  if @exclude_from
-        cmd    << " --exclude #{@exclude}"            if @exclude
+        Array(@exclude).each do |e|
+          cmd  << " --exclude #{e}"
+        end
         cmd    << " --include-from #{@include_from}"  if @include_from
-        cmd    << " --include #{@include}"            if @include
+        Array(@include).each do |i|
+          cmd  << " --include #{i}"
+        end
         cmd    << " --rsh='ssh -p#{@port}'"           if @user && @port
         cmd    << " --delete "                        if @delete
 


### PR DESCRIPTION
A few changes:

* Fixed a bug where the `:include_from` option was setting the `@exclude_from` instance variable. (Fixes issue #51.)
* Removed the `-e` flag when setting exclusions.  `-e` is an alias for `--rsh`, so it has nothing to do with exclusions.
* Allows for an array of pattern for `:exclude` and `:include` options.  Each pattern needs its own flag in the rsync command.  (Implements solution for #52 .)

I was able to confirm that each of these changes worked fine on my site.