### PR TITLE
Deploy multiple stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,13 @@ _rsync_deploy.yml
 _git_deploy.yml
 pull-git
 pull-rsync
+pull-staging-rsync
+pull-production-rsync
 pull-s3
 build
 local-git
 local-rsync
+local-staging-rsync
+local-production-rsync
 .DS_Store
 _site

--- a/lib/octopress-deploy.rb
+++ b/lib/octopress-deploy.rb
@@ -53,6 +53,13 @@ module Octopress
     def self.merge_configs(options={})
       options = check_config(options)
       config  = SafeYAML.load(File.open(options[:config_file])).to_symbol_keys
+
+      if stage = options[:stage]
+        config = config.fetch(stage.to_sym)
+      elsif config.key?(:production)
+        config = config[:production]
+      end
+
       options = config.deep_merge(options)
     end
 

--- a/lib/octopress-deploy/commands.rb
+++ b/lib/octopress-deploy/commands.rb
@@ -7,6 +7,7 @@ module Octopress
           c.version Deploy::VERSION
           c.description "Deploy your Octopress site."
           c.option "config_file", "-c", "--config FILE", "The path to your config file (default: _deploy.yml)"
+          c.option "stage", "-s", "--stage STAGE", "The stage for deployment (default: production)"
 
           c.action do |args, options|
             Octopress::Deploy.push(options)

--- a/test/_clash.yml
+++ b/test/_clash.yml
@@ -1,14 +1,14 @@
 -
   tasks:
     cleanup:
-      - rm -rf build local-rsync pull-rsync pull-s3 .deploy pull-git local-git pull-s3 remote-rsync
-    reset: 
+      - rm -rf build local-rsync local-staging-rsync local-production-rsync pull-staging-rsync pull-production-rsync pull-rsync pull-s3 .deploy pull-git local-git pull-s3 remote-rsync
+    reset:
       - cleanup
       - cp -r source/ _site
       - ruby garbage.rb
 -
   title: Test local Rsync
-  before: 
+  before:
     - reset
     - octopress deploy init rsync --dir local-rsync --config _rsync_deploy_local.yml --force
     - octopress deploy --config _rsync_deploy_local.yml
@@ -16,7 +16,7 @@
 
 -
   title: Test remote Rsync
-  before: 
+  before:
     - reset
     - octopress deploy --config _rsync_deploy.yml
     - octopress deploy pull pull-rsync --config _rsync_deploy.yml
@@ -24,7 +24,7 @@
 
 -
   title: Test local Git
-  before: 
+  before:
     - reset
     - git init --bare local-git
     - octopress deploy init git ./local-git --branch test_git_deploy --dir site --config _git_deploy_local.yml --force
@@ -35,7 +35,7 @@
 
 -
   title: Test remote Git
-  before: 
+  before:
     - reset
     - octopress deploy init git git@github.com:octopress/deploy --branch test_git_deploy --config _git_deploy.yml --force
     - octopress deploy --config _git_deploy.yml
@@ -45,9 +45,27 @@
 
 -
   title: Test S3
-  before: 
+  before:
     - reset
     - octopress deploy s3 --config _s3_deploy.yml
     - octopress deploy pull pull-s3 --config _s3_deploy.yml
   compare: _site pull-s3
+  after: cleanup
+
+-
+  title: Test multistage rsync
+  before:
+    - reset
+    - octopress deploy --config _rsync_deploy_multistage.yml --stage staging
+    - octopress deploy pull pull-staging-rsync --config _rsync_deploy_multistage.yml --stage staging
+  compare: _site pull-staging-rsync
+  after: cleanup
+
+-
+  title: Test multistage rsync default
+  before:
+    - reset
+    - octopress deploy --config _rsync_deploy_multistage.yml
+    - octopress deploy pull pull-production-rsync --config _rsync_deploy_multistage.yml
+  compare: _site pull-production-rsync
   after: cleanup

--- a/test/_rsync_deploy_multistage.yml
+++ b/test/_rsync_deploy_multistage.yml
@@ -1,0 +1,16 @@
+shared: &shared
+  method: rsync                             # How do you want to deploy? git, rsync or s3.
+  site_dir: _site                           # Location of your static site files.
+
+  user:                                     # The user for your host, e.g. user@host.com
+  delete:                                   # Remove files from destination which don't match files in source
+  port:                                     # If your host requires a non standard port
+  flags:  -avz                              # Modify flags as necessary to suit your hosting setup
+
+staging:
+  <<: *shared
+  remote_path: local-staging-rsync
+
+production:
+  <<: *shared
+  remote_path: local-production-rsync


### PR DESCRIPTION
This PR allows for multiple deployment stages in a backwards compatible manner.

By default, it will look for a key named `production` in the config.
