### PR TITLE
fix: escape repo string with Regexp.quote

### DIFF
--- a/lib/octopress-deploy/git.rb
+++ b/lib/octopress-deploy/git.rb
@@ -115,7 +115,7 @@ CONFIG
       end
 
       def git_push
-        if `git remote -v` =~ /#{@remote}\s+#{@repo}.+\(push\)/
+        if `git remote -v` =~ /#{@remote}\s+#{Regexp.quote(@repo)}.+\(push\)/
           `git push #{@remote} #{@branch}`
         else
           remotes = `git remote -v`


### PR DESCRIPTION
### Overview

Use [`Regexp::quote`](http://ruby-doc.org/core-2.2.2/Regexp.html#method-c-quote) method to escape the `@repo` variable when checking if the `remote` deploy repository exists in the `git_push` method.

### Problem

  - Deploying my personal website with [gandi.net](https://www.gandi.net/) who offers a [GIT access for Simple Hosting](http://wiki.gandi.net/en/simple/git) (one of their hosting solution).
  - They use `ssh+git://` as their protocol to access the remote repository (do not ask me why...)
  - The remote repository URL ends up looking like:  
`ssh+git://{login}@git.{datacenter_location}.gpaas.net/{vhost}.git`
  - Because of the `+` character, there are no matches in regular expression in the `git_push` method and the deploy fails.

### Workaround

  - After creating the remote repository and failing the deploy a first time, I escape the `+` character in my `_deploy.yml` file:  
`ssh\+git://{login}@git.{datacenter_location}.gpaas.net/{vhost}.git`
  - I can then retry the deploy and it works.
  - **Alternative**: I can also enter the `.deploy/` directory and do a `git push deploy master` from there.

### Proposed Solution

Use [`Regexp::quote`](http://ruby-doc.org/core-2.2.2/Regexp.html#method-c-quote) to escape the `@repo` variable, which is the most likely to contain a character with a special meaning in a regular expression like it was in my case.