### PR TITLE
enabling use of ERB inside _deploy.yml

### DIFF
--- a/lib/octopress-deploy.rb
+++ b/lib/octopress-deploy.rb
@@ -52,7 +52,7 @@ module Octopress
 
     def self.merge_configs(options={})
       options = check_config(options)
-      config  = SafeYAML.load(File.open(options[:config_file])).to_symbol_keys
+      config  = SafeYAML.load(ERB.new(File.read(options[:config_file])).result).to_symbol_keys
       options = config.deep_merge(options)
     end
 


### PR DESCRIPTION
this patch puts the contents of `_deploy.yml` through ERB which enables, for example, use of custom environment variables for config option values.

i ran across this while upgrading a plain jekyll site to octopress. before that, i was using the [jekyll-s3][0] gem to push to s3. while moving all options from `_jekyll-s3.yml` to `_deploy.yml` i also copied erb code from one to the other which resulted in me not being able to push. the config defaults have been enough for me but i think this can be helpful for others in the progress of migrating and also everybody who's either not using default names for env vars or wishes to use other env vars for any option.

[0]: https://github.com/laurilehmijoki/jekyll-s3