### PR TITLE
s3: parallel upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### unreleased
+- New: Files are now uploaded to S3 in parallel. This can be disabled by setting `parallel: false` in `_deploy.yml`. [#63](https://github.com/octopress/deploy/pull/63)
+
 ### 1.3.0 - 2015-07-05
 - New: Now `_deploy.yml` is processed through ERB, this means you can load configurations for ENV vars pretty easily. [#62](https://github.com/octopress/deploy/pull/62)
 

--- a/lib/octopress-deploy/s3.rb
+++ b/lib/octopress-deploy/s3.rb
@@ -279,10 +279,12 @@ CONFIG
     protected
 
       def write_file? file
+        return true unless @incremental
+
         file_digest = Digest::MD5.file(file).hexdigest
         o = s3_object file
         s3sum = o.etag.tr('"','') if o.exists?
-        @incremental == false || s3sum.to_s != file_digest
+        s3sum.to_s != file_digest
       end
 
       def s3_object file

--- a/lib/octopress-deploy/s3.rb
+++ b/lib/octopress-deploy/s3.rb
@@ -20,7 +20,7 @@ module Octopress
         @distro_id   = options[:distribution_id]   || ENV['AWS_DISTRIBUTION_ID']
         @remote_path = (options[:remote_path]      || '/').sub(/^\//,'')
         @verbose     = options[:verbose]
-        @incremental = options[:incremental]
+        @incremental = options[:incremental]       || true
         @delete      = options[:delete]
         @headers     = options[:headers]           || []
         @remote_path = @remote_path.sub(/^\//,'')  # remove leading slash
@@ -270,7 +270,7 @@ module Octopress
 #{"remote_path: #{options[:remote_path] || '/'}".ljust(40)}  # relative path on bucket where files should be copied.
 #{"region: #{options[:remote_path] || 'us-east-1'}".ljust(40)}  # Region where your bucket is located.
 #{"verbose: #{options[:verbose] || 'false'}".ljust(40)}  # Print out all file operations.
-#{"incremental: #{options[:incremental] || 'false'}".ljust(40)}  # Only upload new/changed files
+#{"incremental: #{options[:incremental] || 'true'}".ljust(40)}  # Only upload new/changed files
 #{"delete: #{options[:delete] || 'false'}".ljust(40)}  # Remove files from destination which do not match source files.
 #{"parallel: #{options[:parallel] || 'true'}".ljust(40)}  # Speed up deployment by uploading files in parallel.
 CONFIG


### PR DESCRIPTION
this pr introduces the use of threads to upload files in parallel -- inspired by `jekyll-s3`.

using this on a site with 18 files (636k) on a 14mbit dsl connection, it cuts the upload time consumption ~~by ~50%. before: ~6 seconds. after: ~3 seconds.~~ by ~25%. before: ~12 seconds. after: ~9 seconds.

this feature will also be configurable in `_deploy.yml` via `parallel: true|false` and defaults to true.

i didn't get around refactoring quite a bit. sorry ;)
